### PR TITLE
usage of unirest is no longer necessary with sendgrid's new php library

### DIFF
--- a/src/SendGrid.php
+++ b/src/SendGrid.php
@@ -23,8 +23,8 @@ class SendGrid extends \SendGrid{
   public function report(Report $report)
   {
     $form = $report->toWebFormat();
-    $form['api_user'] = $this->api_user; 
-    $form['api_key'] = $this->api_key; 
+    $form['api_user'] = $this->apiUser; 
+    $form['api_key'] = $this->apiKey; 
 
     $response = $this->postRequest($report->getUrl(), $form);
 

--- a/src/SendGrid.php
+++ b/src/SendGrid.php
@@ -26,7 +26,7 @@ class SendGrid extends \SendGrid{
     $form['api_user'] = $this->api_user; 
     $form['api_key'] = $this->api_key; 
 
-    $response = \Unirest::post($report->getUrl(), array(), $form );
+    $response = $this->postRequest($report->getUrl(), $form);
 
     return $response->body;
   }


### PR DESCRIPTION
SendGrid's new PHP library no longer uses Unirest to communicate with their API and has built in functions for it.  

This single line change makes this work correctly with their new PHP Library.
